### PR TITLE
Change name from maesh to traefik mesh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Meshery-Maesh
+name: Meshery-traefik-mesh
 on:
   push:
     branches:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
     - name: Get current star count
       run: |
-        echo "STARS=$(curl --silent 'https://api.github.com/repos/layer5io/meshery-maesh' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
+        echo "STARS=$(curl --silent 'https://api.github.com/repos/layer5io/meshery-traefik-mesh' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
     - name: Notify slack
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       uses: pullreminders/slack-action@master
       with:
-        args: '{\"channel\":\"CSK7N9TGX\",\"text\":\"Someone just starred Meshery Adapter for Maesh! (https://github.com/layer5io/meshery-traefik-mesh/stargazers) Total ⭐️: ${{env.STARS}}\"}'
+        args: '{\"channel\":\"CSK7N9TGX\",\"text\":\"Someone just starred Meshery Adapter for Traefik Mesh! (https://github.com/layer5io/meshery-traefik-mesh/stargazers) Total ⭐️: ${{env.STARS}}\"}'

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -13,4 +13,4 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       uses: pullreminders/slack-action@master
       with:
-        args: '{\"channel\":\"CSK7N9TGX\",\"text\":\"Someone just starred Meshery Adapter for Maesh! (https://github.com/layer5io/meshery-maesh/stargazers) Total ⭐️: ${{env.STARS}}\"}'
+        args: '{\"channel\":\"CSK7N9TGX\",\"text\":\"Someone just starred Meshery Adapter for Maesh! (https://github.com/layer5io/meshery-traefik-mesh/stargazers) Total ⭐️: ${{env.STARS}}\"}'

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@
 
 .vscode
 
-meshery-maesh
+meshery-traefik-mesh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM golang:1.13 as bd
 RUN adduser --disabled-login appuser
 WORKDIR /github.com/layer5io/meshery-traefik-mesh
 ADD . .
-RUN GOPROXY=direct GOSUMDB=off go build -ldflags="-w -s" -a -o /meshery-maesh .
-RUN find . -name "*.go" -type f -delete; mv maesh /
+RUN GOPROXY=direct GOSUMDB=off go build -ldflags="-w -s" -a -o /meshery-traefik-mesh .
+RUN find . -name "*.go" -type f -delete; mv traefik-mesh /
 
 FROM alpine
 RUN apk --update add ca-certificates
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-COPY --from=bd /meshery-maesh /app/
-COPY --from=bd /maesh /app/maesh
+COPY --from=bd /meshery-traefik-mesh /app/
+COPY --from=bd /traefik-mesh /app/traefik-mesh
 COPY --from=bd /etc/passwd /etc/passwd
 USER appuser
 WORKDIR /app
-CMD ./meshery-maesh
+CMD ./meshery-traefik-mesh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13 as bd
 RUN adduser --disabled-login appuser
 WORKDIR /github.com/layer5io/meshery-traefik-mesh
 ADD . .
-RUN GOPROXY=direct GOSUMDB=off go build -ldflags="-w -s" -a -o /meshery-traefik-mesh .
+RUN GOPROXY=https://proxy.golang.org GOSUMDB=off go build -ldflags="-w -s" -a -o /meshery-traefik-mesh .
 RUN find . -name "*.go" -type f -delete; mv traefik-mesh /
 
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13 as bd
 RUN adduser --disabled-login appuser
-WORKDIR /github.com/layer5io/meshery-maesh
+WORKDIR /github.com/layer5io/meshery-traefik-mesh
 ADD . .
 RUN GOPROXY=direct GOSUMDB=off go build -ldflags="-w -s" -a -o /meshery-maesh .
 RUN find . -name "*.go" -type f -delete; mv maesh /

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ proto:
 	protoc -I meshes/ meshes/meshops.proto --go_out=plugins=grpc:./meshes/
 
 docker:
-	docker build -t layer5/meshery-maesh .
+	docker build -t layer5/meshery-traefik-mesh .
 
 docker-run:
-	(docker rm -f meshery-maesh) || true
-	docker run --name meshery-maesh -d \
+	(docker rm -f meshery-traefik-mesh) || true
+	docker run --name meshery-traefik-mesh -d \
 	-p 10000:10000 \
 	-e DEBUG=true \
-	layer5/meshery-maesh
+	layer5/meshery-traefik-mesh
 
 run:
 	DEBUG=true go run main.go

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p style="text-align:center;" align="center"><a href="https://layer5.io/meshery"><img align="center" style="margin-bottom:20px;" src="https://raw.githubusercontent.com/layer5io/layer5/master/assets/images/meshery/meshery-logo-tag-light-text-side.png"  width="70%" /></a><br /><br /></p>
 
-# Meshery Adapter for Maesh
+# Meshery Adapter for Traefik Mesh
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/layer5/meshery-maesh.svg)](https://hub.docker.com/r/layer5/meshery-maesh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/layer5io/meshery-traefik-mesh)](https://goreportcard.com/report/github.com/layer5io/meshery-traefik-mesh)
 [![Build Status](https://github.com/layer5io/meshery-traefik-mesh/workflows/Meshery-Maesh/badge.svg)](https://github.com/layer5io/meshery-traefik-mesh/actions)
 [![GitHub](https://img.shields.io/github/license/layer5io/meshery-maesh.svg)](LICENSE)
-[![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/meshery-maesh/help%20wanted.svg)](https://github.com/layer5io/meshery-traefik-mesh/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+[![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/meshery-traefik-mesh/help%20wanted.svg)](https://github.com/layer5io/meshery-traefik-mesh/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 [![Website](https://img.shields.io/website/https/layer5.io/meshery.svg)](https://layer5.io/meshery/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/layer5.svg?label=Follow&style=social)](https://twitter.com/intent/follow?screen_name=mesheryio)
 [![Slack](http://slack.layer5.io/badge.svg)](http://slack.layer5.io)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 # Meshery Adapter for Maesh
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/layer5/meshery-maesh.svg)](https://hub.docker.com/r/layer5/meshery-maesh)
-[![Go Report Card](https://goreportcard.com/badge/github.com/layer5io/meshery-maesh)](https://goreportcard.com/report/github.com/layer5io/meshery-maesh)
-[![Build Status](https://github.com/layer5io/meshery-maesh/workflows/Meshery-Maesh/badge.svg)](https://github.com/layer5io/meshery-maesh/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/layer5io/meshery-traefik-mesh)](https://goreportcard.com/report/github.com/layer5io/meshery-traefik-mesh)
+[![Build Status](https://github.com/layer5io/meshery-traefik-mesh/workflows/Meshery-Maesh/badge.svg)](https://github.com/layer5io/meshery-traefik-mesh/actions)
 [![GitHub](https://img.shields.io/github/license/layer5io/meshery-maesh.svg)](LICENSE)
-[![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/meshery-maesh/help%20wanted.svg)](https://github.com/layer5io/meshery-maesh/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+[![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/meshery-maesh/help%20wanted.svg)](https://github.com/layer5io/meshery-traefik-mesh/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 [![Website](https://img.shields.io/website/https/layer5.io/meshery.svg)](https://layer5.io/meshery/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/layer5.svg?label=Follow&style=social)](https://twitter.com/intent/follow?screen_name=mesheryio)
 [![Slack](http://slack.layer5.io/badge.svg)](http://slack.layer5.io)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/layer5io/meshery-maesh
+module github.com/layer5io/meshery-traefik-mesh
 
 go 1.15
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ var (
 
 	// MeshSpec is the spec for the service mesh associated with this adapter
 	MeshSpec = map[string]string{
-		"name":     "traefik-mesh",
+		"name":     "traefik mesh",
 		"status":   status.None,
 		"traceurl": status.None,
 		"version":  status.None,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 const (
 	// TraefikMeshOperation is the default name for the install
 	// and uninstall commands on the traefik mesh
-	TraefikMeshOperation = "maesh"
+	TraefikMeshOperation = "traefik-mesh"
 )
 
 var (
@@ -29,14 +29,14 @@ var (
 
 	// ServerConfig is the configuration for the gRPC server
 	ServerConfig = map[string]string{
-		"name":    "maesh-adapter",
+		"name":    "traefik-mesh-adapter",
 		"port":    "10006",
 		"version": "v1.0.0",
 	}
 
 	// MeshSpec is the spec for the service mesh associated with this adapter
 	MeshSpec = map[string]string{
-		"name":     "maesh",
+		"name":     "traefik-mesh",
 		"status":   status.None,
 		"traceurl": status.None,
 		"version":  status.None,
@@ -46,7 +46,7 @@ var (
 	ProviderConfig = map[string]string{
 		configprovider.FilePath: configRootPath,
 		configprovider.FileType: "yaml",
-		configprovider.FileName: "maesh",
+		configprovider.FileName: "traefik-mesh",
 	}
 
 	// KubeConfig - Controlling the kubeconfig lifecycle with viper

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	serviceName = "maesh-adaptor"
+	serviceName = "traefik-mesh-adaptor"
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -20,14 +20,14 @@ import (
 	"path"
 	"time"
 
-	"github.com/layer5io/meshery-maesh/traefik"
+	"github.com/layer5io/meshery-traefik-mesh/traefik"
 	"github.com/layer5io/meshkit/logger"
 
 	// "github.com/layer5io/meshkit/tracing"
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/api/grpc"
 	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
-	"github.com/layer5io/meshery-maesh/internal/config"
+	"github.com/layer5io/meshery-traefik-mesh/internal/config"
 )
 
 var (

--- a/traefik/install.go
+++ b/traefik/install.go
@@ -78,8 +78,9 @@ func (mesh *Mesh) applyHelmChart(del bool, version, namespace string) error {
 			Chart:      chart,
 			Version:    chartVersion,
 		},
-		Namespace: namespace,
-		Delete:    del,
+		Namespace:       namespace,
+		Delete:          del,
+		CreateNamespace: true,
 	})
 
 	return err

--- a/traefik/traefik.go
+++ b/traefik/traefik.go
@@ -8,7 +8,7 @@ import (
 	"github.com/layer5io/meshery-adapter-library/common"
 	adapterconfig "github.com/layer5io/meshery-adapter-library/config"
 	"github.com/layer5io/meshery-adapter-library/status"
-	internalConfig "github.com/layer5io/meshery-maesh/internal/config"
+	internalConfig "github.com/layer5io/meshery-traefik-mesh/internal/config"
 	"github.com/layer5io/meshkit/logger"
 )
 


### PR DESCRIPTION
**Description**
This PR changes he following:
1. Change name from maesh to traefik mesh at almost all of the places **except** the published docker images as they are controlled from github secrets.
2. Enable creating namespace if the namespace doesn't already exists.

Tests done (within the container):
- [x] Installing and uninstalling traefik mesh
- [x] Installing and uninstalling sample app (emojivoto)

**Note for reviewers**
